### PR TITLE
Fix custom non-CLI driver

### DIFF
--- a/src/LogHandlers/NonConsole.php
+++ b/src/LogHandlers/NonConsole.php
@@ -20,6 +20,11 @@ class NonConsole extends NullLogger implements HandlerInterface {
         return false;
     }
 
+    public function getProcessors(): array
+    {
+        return [];
+    }
+
     public function handle(array $record): bool
     {
         return false;


### PR DESCRIPTION
Fixes https://github.com/dev-this/laravel-console-logg/issues/8

```
[2022-07-13 10:07:53] laravel.EMERGENCY: Unable to create configured logger. Using emergency logger. {"exception":"[object] (Error(code: 0): Call to undefined method DevThis\\ConsoleLogg\\LogHandlers\\NonConsole::getProcessors() at /var/www/html/vendor/laravel/framework/src/Illuminate/Log/Logger.php:308)
[stacktrace]
#0 /var/www/html/vendor/laravel/framework/src/Illuminate/Log/LogManager.php(261): Illuminate\\Log\\Logger->__call('getProcessors', Array)
#1 [internal function]: Illuminate\\Log\\LogManager->Illuminate\\Log\\{closure}('console-logg', 1)
#2 /var/www/html/vendor/laravel/framework/src/Illuminate/Collections/Collection.php(695): array_map(Object(Closure), Array, Array)
#3 /var/www/html/vendor/laravel/framework/src/Illuminate/Collections/Traits/EnumeratesValues.php(354): Illuminate\\Support\\Collection->map(Object(Closure))
#4 /var/www/html/vendor/laravel/framework/src/Illuminate/Log/LogManager.php(262): Illuminate\\Support\\Collection->flatMap(Object(Closure))
#5 /var/www/html/vendor/laravel/framework/src/Illuminate/Log/LogManager.php(210): Illuminate\\Log\\LogManager->createStackDriver(Array)
#6 /var/www/html/vendor/laravel/framework/src/Illuminate/Log/LogManager.php(125): Illuminate\\Log\\LogManager->resolve('stack', Array)
#7 /var/www/html/vendor/laravel/framework/src/Illuminate/Log/LogManager.php(112): Illuminate\\Log\\LogManager->get('stack')
```